### PR TITLE
i18n機能を実装。ja.yml, en.ymlを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,5 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'carrierwave'
+
+gem 'i18n_generators'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    i18n_generators (2.2.2)
+      activerecord (>= 3.0.0)
+      railties (>= 3.0.0)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -250,6 +253,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   carrierwave
+  i18n_generators
   jbuilder (~> 2.7)
   listen (~> 3.3)
   puma (~> 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :set_locale
+
+  # URLパラメータにロケール情報を渡すという処理
+  def default_url_options
+    { locale: I18n.locale }
+  end
+
+  # リンクの多言語化に対応する
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -23,7 +23,7 @@ class BooksController < ApplicationController
   def create
     @book = Book.new(book_params)
     if @book.save
-      redirect_to @book, notice: t('.success')
+      redirect_to @book, notice: t('helpers.notice.success.create', model: @book.title)
     else
       render :new
     end
@@ -32,7 +32,7 @@ class BooksController < ApplicationController
   # PATCH/PUT /books/1
   def update
     if @book.update(book_params)
-      redirect_to @book, notice: t('.success')
+      redirect_to @book, notice: t('helpers.notice.success.update', model: @book.title)
     else
       render :edit
     end
@@ -41,7 +41,7 @@ class BooksController < ApplicationController
   # DELETE /books/1
   def destroy
     @book.destroy
-    redirect_to books_url, notice: t('.success')
+    redirect_to books_url, notice: t('helpers.notice.success.destroy', model: @book.title)
   end
 
   private

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -4,13 +4,11 @@ class BooksController < ApplicationController
   before_action :set_book, only: %i[show edit update destroy]
 
   # GET /books
-  # GET /books.json
   def index
     @books = Book.all
   end
 
   # GET /books/1
-  # GET /books/1.json
   def show; end
 
   # GET /books/new
@@ -22,43 +20,28 @@ class BooksController < ApplicationController
   def edit; end
 
   # POST /books
-  # POST /books.json
   def create
     @book = Book.new(book_params)
-
-    respond_to do |format|
-      if @book.save
-        format.html { redirect_to @book, notice: 'Book was successfully created.' }
-        format.json { render :show, status: :created, location: @book }
-      else
-        format.html { render :new }
-        format.json { render json: @book.errors, status: :unprocessable_entity }
-      end
+    if @book.save
+      redirect_to @book, notice: t('.success')
+    else
+      render :new
     end
   end
 
   # PATCH/PUT /books/1
-  # PATCH/PUT /books/1.json
   def update
-    respond_to do |format|
-      if @book.update(book_params)
-        format.html { redirect_to @book, notice: 'Book was successfully updated.' }
-        format.json { render :show, status: :ok, location: @book }
-      else
-        format.html { render :edit }
-        format.json { render json: @book.errors, status: :unprocessable_entity }
-      end
+    if @book.update(book_params)
+      redirect_to @book, notice: t('.success')
+    else
+      render :edit
     end
   end
 
   # DELETE /books/1
-  # DELETE /books/1.json
   def destroy
     @book.destroy
-    respond_to do |format|
-      format.html { redirect_to books_url, notice: 'Book was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to books_url, notice: t('.success')
   end
 
   private

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>Editing Book</h1>
+<h1><%= t('.editing_book') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Show', @book %> |
-<%= link_to 'Back', books_path %>
+<%= link_to t('.show'), @book %> |
+<%= link_to t('.back'), books_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Books</h1>
+<h1><%= t('.books') %></h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Memo</th>
-      <th>Author</th>
-      <th>Picture</th>
+      <th><%= t('.title') %></th>
+      <th><%= t('.memo') %></th>
+      <th><%= t('.author') %></th>
+      <th><%= t('.picture') %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -20,9 +20,9 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to 'Show', book %></td>
-        <td><%= link_to 'Edit', edit_book_path(book) %></td>
-        <td><%= link_to 'Destroy', book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to t('.show'), book %></td>
+        <td><%= link_to t('.edit'), edit_book_path(book) %></td>
+        <td><%= link_to t('.destroy'), book, method: :delete, data: { confirm: t('.confirm') } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to 'New Book', new_book_path %>
+<%= link_to t('.new_book'), new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
-<h1><%= t('.books') %></h1>
+<h1><%= Book.model_name.human %></h1>
 
 <table>
   <thead>
     <tr>
-      <th><%= t('.title') %></th>
-      <th><%= t('.memo') %></th>
-      <th><%= t('.author') %></th>
-      <th><%= t('.picture') %></th>
+      <th><%= Book.human_attribute_name(:title) %></th>
+      <th><%= Book.human_attribute_name(:memo) %></th>
+      <th><%= Book.human_attribute_name(:author) %></th>
+      <th><%= Book.human_attribute_name(:picture) %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Book</h1>
+<h1><%= t('.new_book') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Back', books_path %>
+<%= link_to t('.back'), books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,22 +1,22 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong><%= t('.title') %>:</strong>
+  <strong><%= Book.human_attribute_name(:title) %>:</strong>
   <%= @book.title %>
 </p>
 
 <p>
-  <strong><%= t('.memo') %>:</strong>
+  <strong><%= Book.human_attribute_name(:memo) %>:</strong>
   <%= @book.memo %>
 </p>
 
 <p>
-  <strong><%= t('.author') %>:</strong>
+  <strong><%= Book.human_attribute_name(:author) %>:</strong>
   <%= @book.author %>
 </p>
 
 <p>
-  <strong><%= t('.picture') %>:</strong>
+  <strong><%= Book.human_attribute_name(:picture) %>:</strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,24 +1,24 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong><%= t('.title') %>:</strong>
   <%= @book.title %>
 </p>
 
 <p>
-  <strong>Memo:</strong>
+  <strong><%= t('.memo') %>:</strong>
   <%= @book.memo %>
 </p>
 
 <p>
-  <strong>Author:</strong>
+  <strong><%= t('.author') %>:</strong>
   <%= @book.author %>
 </p>
 
 <p>
-  <strong>Picture:</strong>
+  <strong><%= t('.picture') %>:</strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to 'Edit', edit_book_path(@book) %> |
-<%= link_to 'Back', books_path %>
+<%= link_to t('.edit'), edit_book_path(@book) %> |
+<%= link_to t('.back'), books_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module BooksApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,11 +1,6 @@
 en:
   books:
     index:
-      books: Books
-      title: Title
-      memo: Memo
-      auhor: Author
-      picture: Picture
       show: Show
       edit: Edit
       destroy: Destroy
@@ -16,21 +11,11 @@ en:
       show: Show
       back: Back
     show:
-      title: Title
-      memo: Memo
-      author: Author
-      picture: Picture
       edit: Edit
       back: Back
     new:
       new_book: New Book
       back: Back
-    create:
-      success: Book was successfully created.
-    update:
-      success: Book was successfully updated.
-    destroy:
-      success: Book was successfully deleted.
 
   activerecord:
     models:
@@ -50,3 +35,12 @@ en:
       create: Create %{model}
       submit: Save %{model}
       update: Update %{model}
+    notice:
+      success:
+        create: '%{model} was successfully created.'
+        update: '%{model} was successfully updated.'
+        destroy: '%{model} was successfully deleted.'
+      failure:
+        create: Failed to create the %{model}.
+        update: Failed to update the %{model}.
+        destroy: Failed to destroy the %{model}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,52 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  books:
+    index:
+      books: Books
+      title: Title
+      memo: Memo
+      auhor: Author
+      picture: Picture
+      show: Show
+      edit: Edit
+      destroy: Destroy
+      new_book: New Book
+      confirm: Are you sure?
+    edit:
+      editing_book: Editing Book
+      show: Show
+      back: Back
+    show:
+      title: Title
+      memo: Memo
+      author: Author
+      picture: Picture
+      edit: Edit
+      back: Back
+    new:
+      new_book: New Book
+      back: Back
+    create:
+      success: Book was successfully created.
+    update:
+      success: Book was successfully updated.
+    destroy:
+      success: Book was successfully deleted.
+
+  activerecord:
+    models:
+      book: Book
+
+    attributes:
+      book:
+        author: Author
+        memo: Memo
+        picture: Picture
+        title: Title
+
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,11 +1,6 @@
 ja:
   books:
     index:
-      books: '書籍一覧'
-      title: 'タイトル'
-      memo: 'メモ'
-      author: '著者'
-      picture: '画像'
       show: '詳細'
       edit: '編集'
       destroy: '削除'
@@ -16,21 +11,11 @@ ja:
       show: '詳細'
       back: '戻る'
     show:
-      title: 'タイトル'
-      memo: 'メモ'
-      author: '著者'
-      picture: '画像'
       edit: '編集'
       back: '戻る'
     new:
       new_book: '新規作成'
       back: '戻る'
-    create:
-      success: '本の作成に成功しました'
-    update:
-      success: '本の更新に成功しました'
-    destroy:
-      success: '本の削除に成功しました'
 
   activerecord:
     models:
@@ -41,7 +26,7 @@ ja:
         author: 著者
         memo: メモ
         picture: 画像
-        title: 題名
+        title: タイトル
 
   helpers:
     select:
@@ -50,3 +35,12 @@ ja:
       create: '%{model}を作成'
       submit: '%{model}を保存'
       update: '%{model}を更新'
+    notice:
+      success:
+        create: '%{model}の作成に成功しました'
+        update: '%{model}の更新に成功しました'
+        destroy: '%{model}の削除に成功しました'
+      failure:
+        create: '%{model}の作成に失敗しました'
+        update: '%{model}の更新に失敗しました'
+        destroy: '%{model}の削除に失敗しました'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,52 @@
+ja:
+  books:
+    index:
+      books: '書籍一覧'
+      title: 'タイトル'
+      memo: 'メモ'
+      author: '著者'
+      picture: '画像'
+      show: '詳細'
+      edit: '編集'
+      destroy: '削除'
+      new_book: '新規作成'
+      confirm: '本当に実行しますか？'
+    edit:
+      editing_book: '編集中の書籍'
+      show: '詳細'
+      back: '戻る'
+    show:
+      title: 'タイトル'
+      memo: 'メモ'
+      author: '著者'
+      picture: '画像'
+      edit: '編集'
+      back: '戻る'
+    new:
+      new_book: '新規作成'
+      back: '戻る'
+    create:
+      success: '本の作成に成功しました'
+    update:
+      success: '本の更新に成功しました'
+    destroy:
+      success: '本の削除に成功しました'
+
+  activerecord:
+    models:
+      book: 本
+
+    attributes:
+      book:
+        author: 著者
+        memo: メモ
+        picture: 画像
+        title: 題名
+
+  helpers:
+    select:
+      prompt: '選んでください'
+    submit:
+      create: '%{model}を作成'
+      submit: '%{model}を保存'
+      update: '%{model}を更新'


### PR DESCRIPTION
1. `config/application.rb`ファイルに、デフォルトを日本語に設定・config/locales下の更に深いディレクトリのyml, rbファイルを読み込むように記述した。
2. `application_controller`ファイルに、URLパラメータにロケール情報を渡すメソッド・ロケール情報がなければデフォルトを渡すよう設定したメソッドを記述。
3. Bookモデル、Bookのビュー用のja.yml, en.ymlを追加
4. それぞれのビューとコントローラーで多言語対応にしたい文字列をI18nのtメソッドで記述